### PR TITLE
Switch to Fabric lifecycle events

### DIFF
--- a/common/src/main/java/org/terraform/main/TerraformGeneratorFabric.java
+++ b/common/src/main/java/org/terraform/main/TerraformGeneratorFabric.java
@@ -1,19 +1,17 @@
 package org.terraform.main;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 
 public class TerraformGeneratorFabric implements ModInitializer {
+
+    private final TerraformGeneratorPlugin plugin = new TerraformGeneratorPlugin();
+
     @Override
     public void onInitialize() {
-        // Basic Fabric initialization
         System.out.println("TerraformGenerator fabric mod initializing");
-        // Reuse existing plugin initialization logic where possible
-        try {
-            TerraformGeneratorPlugin plugin = new TerraformGeneratorPlugin();
-            plugin.onEnable();
-        } catch (Exception e) {
-            System.err.println("Failed to run plugin initialization: " + e.getMessage());
-            e.printStackTrace();
-        }
+
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> plugin.initialize());
+        ServerLifecycleEvents.SERVER_STOPPED.register(server -> plugin.shutdown());
     }
 }


### PR DESCRIPTION
## Summary
- remove Bukkit `JavaPlugin` inheritance from `TerraformGeneratorPlugin`
- setup Fabric lifecycle callbacks for initialization
- adjust plugin initialization method

## Testing
- `./gradlew build -x test` *(fails: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841406b5d84832d960c71ac4b23f7a1