### PR TITLE
Introduce fabric injector base

### DIFF
--- a/common/src/main/java/org/terraform/coregen/fabric/FabricNMSInjectorAbstract.java
+++ b/common/src/main/java/org/terraform/coregen/fabric/FabricNMSInjectorAbstract.java
@@ -1,0 +1,40 @@
+package org.terraform.coregen.fabric;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.jetbrains.annotations.Nullable;
+import org.terraform.coregen.BlockDataFixerAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataICAAbstract;
+
+/**
+ * Base injector used when running as a Fabric mod. Methods
+ * use Mojang mappings rather than Bukkit APIs.
+ */
+public abstract class FabricNMSInjectorAbstract {
+    public void startupTasks() {}
+
+    @Nullable
+    public BlockDataFixerAbstract getBlockDataFixer() { return null; }
+
+    /**
+     * Attempt to hook the chunk generator for the provided world.
+     * @return true if the injection succeeded.
+     */
+    public abstract boolean attemptInject(ServerLevel world);
+
+    /**
+     * Obtain ICA data for the given world or chunk.
+     */
+    public abstract PopulatorDataICAAbstract getICAData(ServerLevel world);
+
+    public abstract @Nullable PopulatorDataICAAbstract getICAData(PopulatorDataAbstract data);
+
+    /**
+     * Store a bee in the hive located at the given position.
+     */
+    public abstract void storeBee(ServerLevel world, BlockPos hivePos);
+
+    public int getMinY() { return 0; }
+    public int getMaxY() { return 256; }
+}

--- a/common/src/main/java/org/terraform/main/TerraformGeneratorFabric.java
+++ b/common/src/main/java/org/terraform/main/TerraformGeneratorFabric.java
@@ -2,6 +2,8 @@ package org.terraform.main;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
+import net.minecraft.server.level.ServerLevel;
 
 public class TerraformGeneratorFabric implements ModInitializer {
 
@@ -13,5 +15,8 @@ public class TerraformGeneratorFabric implements ModInitializer {
 
         ServerLifecycleEvents.SERVER_STARTED.register(server -> plugin.initialize());
         ServerLifecycleEvents.SERVER_STOPPED.register(server -> plugin.shutdown());
+
+        ServerWorldEvents.LOAD.register((ServerLevel world) -> plugin.onFabricWorldLoad(world));
+        ServerWorldEvents.UNLOAD.register((ServerLevel world) -> plugin.onFabricWorldUnload(world));
     }
 }

--- a/implementation/v1_18_R2/build.gradle.kts
+++ b/implementation/v1_18_R2/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.18.2-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
     compileOnly("com.github.AvarionMC:yaml:1.1.7")
+    compileOnly("net.fabricmc:fabric-loader:0.14.21")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/implementation/v1_18_R2/src/main/java/org/terraform/v1_18_R2/FabricNMSInjector.java
+++ b/implementation/v1_18_R2/src/main/java/org/terraform/v1_18_R2/FabricNMSInjector.java
@@ -1,0 +1,49 @@
+package org.terraform.v1_18_R2;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.jetbrains.annotations.Nullable;
+import org.terraform.coregen.BlockDataFixerAbstract;
+import org.terraform.coregen.fabric.FabricNMSInjectorAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataICAAbstract;
+import org.terraform.data.TerraformWorld;
+
+/**
+ * Placeholder Fabric injector for v1_18_R2.
+ */
+public class FabricNMSInjector extends FabricNMSInjectorAbstract {
+    @Override
+    public void startupTasks() {
+        CustomBiomeHandler.init();
+    }
+
+    @Override
+    public @Nullable BlockDataFixerAbstract getBlockDataFixer() {
+        return new BlockDataFixer();
+    }
+
+    @Override
+    public boolean attemptInject(ServerLevel world) {
+        TerraformWorld tw = TerraformWorld.get(world.dimension().location().toString(), world.getSeed());
+        tw.minY = -64;
+        tw.maxY = 320;
+        // TODO implement actual Fabric chunk generator injection
+        return false;
+    }
+
+    @Override
+    public PopulatorDataICAAbstract getICAData(ServerLevel world) {
+        return null;
+    }
+
+    @Override
+    public @Nullable PopulatorDataICAAbstract getICAData(PopulatorDataAbstract data) {
+        return null;
+    }
+
+    @Override
+    public void storeBee(ServerLevel world, BlockPos hivePos) {
+        // TODO implement storing bees on Fabric
+    }
+}

--- a/implementation/v1_19_R3/build.gradle.kts
+++ b/implementation/v1_19_R3/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.19.4-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
     compileOnly("com.github.AvarionMC:yaml:1.1.7")
+    compileOnly("net.fabricmc:fabric-loader:0.14.21")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/implementation/v1_19_R3/src/main/java/org/terraform/v1_19_R3/FabricNMSInjector.java
+++ b/implementation/v1_19_R3/src/main/java/org/terraform/v1_19_R3/FabricNMSInjector.java
@@ -1,0 +1,49 @@
+package org.terraform.v1_19_R3;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.jetbrains.annotations.Nullable;
+import org.terraform.coregen.BlockDataFixerAbstract;
+import org.terraform.coregen.fabric.FabricNMSInjectorAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataICAAbstract;
+import org.terraform.data.TerraformWorld;
+
+/**
+ * Placeholder Fabric injector for v1_19_R3.
+ */
+public class FabricNMSInjector extends FabricNMSInjectorAbstract {
+    @Override
+    public void startupTasks() {
+        CustomBiomeHandler.init();
+    }
+
+    @Override
+    public @Nullable BlockDataFixerAbstract getBlockDataFixer() {
+        return new BlockDataFixer();
+    }
+
+    @Override
+    public boolean attemptInject(ServerLevel world) {
+        TerraformWorld tw = TerraformWorld.get(world.dimension().location().toString(), world.getSeed());
+        tw.minY = -64;
+        tw.maxY = 320;
+        // TODO implement actual Fabric chunk generator injection
+        return false;
+    }
+
+    @Override
+    public PopulatorDataICAAbstract getICAData(ServerLevel world) {
+        return null;
+    }
+
+    @Override
+    public @Nullable PopulatorDataICAAbstract getICAData(PopulatorDataAbstract data) {
+        return null;
+    }
+
+    @Override
+    public void storeBee(ServerLevel world, BlockPos hivePos) {
+        // TODO implement storing bees on Fabric
+    }
+}

--- a/implementation/v1_20_R1/build.gradle.kts
+++ b/implementation/v1_20_R1/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.20.1-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
     compileOnly("com.github.AvarionMC:yaml:1.1.7")
+    compileOnly("net.fabricmc:fabric-loader:0.14.21")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/implementation/v1_20_R1/src/main/java/org/terraform/v1_20_R1/FabricNMSInjector.java
+++ b/implementation/v1_20_R1/src/main/java/org/terraform/v1_20_R1/FabricNMSInjector.java
@@ -1,0 +1,49 @@
+package org.terraform.v1_20_R1;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.jetbrains.annotations.Nullable;
+import org.terraform.coregen.BlockDataFixerAbstract;
+import org.terraform.coregen.fabric.FabricNMSInjectorAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataICAAbstract;
+import org.terraform.data.TerraformWorld;
+
+/**
+ * Placeholder Fabric injector for v1_20_R1.
+ */
+public class FabricNMSInjector extends FabricNMSInjectorAbstract {
+    @Override
+    public void startupTasks() {
+        CustomBiomeHandler.init();
+    }
+
+    @Override
+    public @Nullable BlockDataFixerAbstract getBlockDataFixer() {
+        return new BlockDataFixer();
+    }
+
+    @Override
+    public boolean attemptInject(ServerLevel world) {
+        TerraformWorld tw = TerraformWorld.get(world.dimension().location().toString(), world.getSeed());
+        tw.minY = -64;
+        tw.maxY = 320;
+        // TODO implement actual Fabric chunk generator injection
+        return false;
+    }
+
+    @Override
+    public PopulatorDataICAAbstract getICAData(ServerLevel world) {
+        return null;
+    }
+
+    @Override
+    public @Nullable PopulatorDataICAAbstract getICAData(PopulatorDataAbstract data) {
+        return null;
+    }
+
+    @Override
+    public void storeBee(ServerLevel world, BlockPos hivePos) {
+        // TODO implement storing bees on Fabric
+    }
+}

--- a/implementation/v1_20_R2/build.gradle.kts
+++ b/implementation/v1_20_R2/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.20.2-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
     compileOnly("com.github.AvarionMC:yaml:1.1.7")
+    compileOnly("net.fabricmc:fabric-loader:0.14.21")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/implementation/v1_20_R2/src/main/java/org/terraform/v1_20_R2/FabricNMSInjector.java
+++ b/implementation/v1_20_R2/src/main/java/org/terraform/v1_20_R2/FabricNMSInjector.java
@@ -1,0 +1,49 @@
+package org.terraform.v1_20_R2;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.jetbrains.annotations.Nullable;
+import org.terraform.coregen.BlockDataFixerAbstract;
+import org.terraform.coregen.fabric.FabricNMSInjectorAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataICAAbstract;
+import org.terraform.data.TerraformWorld;
+
+/**
+ * Placeholder Fabric injector for v1_20_R2.
+ */
+public class FabricNMSInjector extends FabricNMSInjectorAbstract {
+    @Override
+    public void startupTasks() {
+        CustomBiomeHandler.init();
+    }
+
+    @Override
+    public @Nullable BlockDataFixerAbstract getBlockDataFixer() {
+        return new BlockDataFixer();
+    }
+
+    @Override
+    public boolean attemptInject(ServerLevel world) {
+        TerraformWorld tw = TerraformWorld.get(world.dimension().location().toString(), world.getSeed());
+        tw.minY = -64;
+        tw.maxY = 320;
+        // TODO implement actual Fabric chunk generator injection
+        return false;
+    }
+
+    @Override
+    public PopulatorDataICAAbstract getICAData(ServerLevel world) {
+        return null;
+    }
+
+    @Override
+    public @Nullable PopulatorDataICAAbstract getICAData(PopulatorDataAbstract data) {
+        return null;
+    }
+
+    @Override
+    public void storeBee(ServerLevel world, BlockPos hivePos) {
+        // TODO implement storing bees on Fabric
+    }
+}

--- a/implementation/v1_20_R3/build.gradle.kts
+++ b/implementation/v1_20_R3/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.20.3-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
     compileOnly("com.github.AvarionMC:yaml:1.1.7")
+    compileOnly("net.fabricmc:fabric-loader:0.14.21")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/implementation/v1_20_R3/src/main/java/org/terraform/v1_20_R3/FabricNMSInjector.java
+++ b/implementation/v1_20_R3/src/main/java/org/terraform/v1_20_R3/FabricNMSInjector.java
@@ -1,0 +1,49 @@
+package org.terraform.v1_20_R3;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.jetbrains.annotations.Nullable;
+import org.terraform.coregen.BlockDataFixerAbstract;
+import org.terraform.coregen.fabric.FabricNMSInjectorAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataICAAbstract;
+import org.terraform.data.TerraformWorld;
+
+/**
+ * Placeholder Fabric injector for v1_20_R3.
+ */
+public class FabricNMSInjector extends FabricNMSInjectorAbstract {
+    @Override
+    public void startupTasks() {
+        CustomBiomeHandler.init();
+    }
+
+    @Override
+    public @Nullable BlockDataFixerAbstract getBlockDataFixer() {
+        return new BlockDataFixer();
+    }
+
+    @Override
+    public boolean attemptInject(ServerLevel world) {
+        TerraformWorld tw = TerraformWorld.get(world.dimension().location().toString(), world.getSeed());
+        tw.minY = -64;
+        tw.maxY = 320;
+        // TODO implement actual Fabric chunk generator injection
+        return false;
+    }
+
+    @Override
+    public PopulatorDataICAAbstract getICAData(ServerLevel world) {
+        return null;
+    }
+
+    @Override
+    public @Nullable PopulatorDataICAAbstract getICAData(PopulatorDataAbstract data) {
+        return null;
+    }
+
+    @Override
+    public void storeBee(ServerLevel world, BlockPos hivePos) {
+        // TODO implement storing bees on Fabric
+    }
+}

--- a/implementation/v1_20_R4/build.gradle.kts
+++ b/implementation/v1_20_R4/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.20.5-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
     compileOnly("com.github.AvarionMC:yaml:1.1.7")
+    compileOnly("net.fabricmc:fabric-loader:0.14.21")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/implementation/v1_20_R4/src/main/java/org/terraform/v1_20_R4/FabricNMSInjector.java
+++ b/implementation/v1_20_R4/src/main/java/org/terraform/v1_20_R4/FabricNMSInjector.java
@@ -1,0 +1,49 @@
+package org.terraform.v1_20_R4;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.jetbrains.annotations.Nullable;
+import org.terraform.coregen.BlockDataFixerAbstract;
+import org.terraform.coregen.fabric.FabricNMSInjectorAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataICAAbstract;
+import org.terraform.data.TerraformWorld;
+
+/**
+ * Placeholder Fabric injector for v1_20_R4.
+ */
+public class FabricNMSInjector extends FabricNMSInjectorAbstract {
+    @Override
+    public void startupTasks() {
+        CustomBiomeHandler.init();
+    }
+
+    @Override
+    public @Nullable BlockDataFixerAbstract getBlockDataFixer() {
+        return new BlockDataFixer();
+    }
+
+    @Override
+    public boolean attemptInject(ServerLevel world) {
+        TerraformWorld tw = TerraformWorld.get(world.dimension().location().toString(), world.getSeed());
+        tw.minY = -64;
+        tw.maxY = 320;
+        // TODO implement actual Fabric chunk generator injection
+        return false;
+    }
+
+    @Override
+    public PopulatorDataICAAbstract getICAData(ServerLevel world) {
+        return null;
+    }
+
+    @Override
+    public @Nullable PopulatorDataICAAbstract getICAData(PopulatorDataAbstract data) {
+        return null;
+    }
+
+    @Override
+    public void storeBee(ServerLevel world, BlockPos hivePos) {
+        // TODO implement storing bees on Fabric
+    }
+}

--- a/implementation/v1_21_R1/build.gradle.kts
+++ b/implementation/v1_21_R1/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.21.1-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
     compileOnly("com.github.AvarionMC:yaml:1.1.7")
+    compileOnly("net.fabricmc:fabric-loader:0.14.21")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/implementation/v1_21_R1/src/main/java/org/terraform/v1_21_R1/FabricNMSInjector.java
+++ b/implementation/v1_21_R1/src/main/java/org/terraform/v1_21_R1/FabricNMSInjector.java
@@ -1,0 +1,49 @@
+package org.terraform.v1_21_R1;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.jetbrains.annotations.Nullable;
+import org.terraform.coregen.BlockDataFixerAbstract;
+import org.terraform.coregen.fabric.FabricNMSInjectorAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataICAAbstract;
+import org.terraform.data.TerraformWorld;
+
+/**
+ * Placeholder Fabric injector for v1_21_R1.
+ */
+public class FabricNMSInjector extends FabricNMSInjectorAbstract {
+    @Override
+    public void startupTasks() {
+        CustomBiomeHandler.init();
+    }
+
+    @Override
+    public @Nullable BlockDataFixerAbstract getBlockDataFixer() {
+        return new BlockDataFixer();
+    }
+
+    @Override
+    public boolean attemptInject(ServerLevel world) {
+        TerraformWorld tw = TerraformWorld.get(world.dimension().location().toString(), world.getSeed());
+        tw.minY = -64;
+        tw.maxY = 320;
+        // TODO implement actual Fabric chunk generator injection
+        return false;
+    }
+
+    @Override
+    public PopulatorDataICAAbstract getICAData(ServerLevel world) {
+        return null;
+    }
+
+    @Override
+    public @Nullable PopulatorDataICAAbstract getICAData(PopulatorDataAbstract data) {
+        return null;
+    }
+
+    @Override
+    public void storeBee(ServerLevel world, BlockPos hivePos) {
+        // TODO implement storing bees on Fabric
+    }
+}

--- a/implementation/v1_21_R2/build.gradle.kts
+++ b/implementation/v1_21_R2/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.21.3-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
     compileOnly("com.github.AvarionMC:yaml:1.1.7")
+    compileOnly("net.fabricmc:fabric-loader:0.14.21")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/implementation/v1_21_R2/src/main/java/org/terraform/v1_21_R2/FabricNMSInjector.java
+++ b/implementation/v1_21_R2/src/main/java/org/terraform/v1_21_R2/FabricNMSInjector.java
@@ -1,0 +1,49 @@
+package org.terraform.v1_21_R2;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.jetbrains.annotations.Nullable;
+import org.terraform.coregen.BlockDataFixerAbstract;
+import org.terraform.coregen.fabric.FabricNMSInjectorAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataICAAbstract;
+import org.terraform.data.TerraformWorld;
+
+/**
+ * Placeholder Fabric injector for v1_21_R2.
+ */
+public class FabricNMSInjector extends FabricNMSInjectorAbstract {
+    @Override
+    public void startupTasks() {
+        CustomBiomeHandler.init();
+    }
+
+    @Override
+    public @Nullable BlockDataFixerAbstract getBlockDataFixer() {
+        return new BlockDataFixer();
+    }
+
+    @Override
+    public boolean attemptInject(ServerLevel world) {
+        TerraformWorld tw = TerraformWorld.get(world.dimension().location().toString(), world.getSeed());
+        tw.minY = -64;
+        tw.maxY = 320;
+        // TODO implement actual Fabric chunk generator injection
+        return false;
+    }
+
+    @Override
+    public PopulatorDataICAAbstract getICAData(ServerLevel world) {
+        return null;
+    }
+
+    @Override
+    public @Nullable PopulatorDataICAAbstract getICAData(PopulatorDataAbstract data) {
+        return null;
+    }
+
+    @Override
+    public void storeBee(ServerLevel world, BlockPos hivePos) {
+        // TODO implement storing bees on Fabric
+    }
+}

--- a/implementation/v1_21_R3/build.gradle.kts
+++ b/implementation/v1_21_R3/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.21.4-R0.1-SNAPSHOT")
 	compileOnly("org.jetbrains:annotations:20.1.0")
     compileOnly("com.github.AvarionMC:yaml:1.1.7")
+    compileOnly("net.fabricmc:fabric-loader:0.14.21")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/implementation/v1_21_R3/src/main/java/org/terraform/v1_21_R3/FabricNMSInjector.java
+++ b/implementation/v1_21_R3/src/main/java/org/terraform/v1_21_R3/FabricNMSInjector.java
@@ -1,0 +1,49 @@
+package org.terraform.v1_21_R3;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.jetbrains.annotations.Nullable;
+import org.terraform.coregen.BlockDataFixerAbstract;
+import org.terraform.coregen.fabric.FabricNMSInjectorAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataICAAbstract;
+import org.terraform.data.TerraformWorld;
+
+/**
+ * Placeholder Fabric injector for v1_21_R3.
+ */
+public class FabricNMSInjector extends FabricNMSInjectorAbstract {
+    @Override
+    public void startupTasks() {
+        CustomBiomeHandler.init();
+    }
+
+    @Override
+    public @Nullable BlockDataFixerAbstract getBlockDataFixer() {
+        return new BlockDataFixer();
+    }
+
+    @Override
+    public boolean attemptInject(ServerLevel world) {
+        TerraformWorld tw = TerraformWorld.get(world.dimension().location().toString(), world.getSeed());
+        tw.minY = -64;
+        tw.maxY = 320;
+        // TODO implement actual Fabric chunk generator injection
+        return false;
+    }
+
+    @Override
+    public PopulatorDataICAAbstract getICAData(ServerLevel world) {
+        return null;
+    }
+
+    @Override
+    public @Nullable PopulatorDataICAAbstract getICAData(PopulatorDataAbstract data) {
+        return null;
+    }
+
+    @Override
+    public void storeBee(ServerLevel world, BlockPos hivePos) {
+        // TODO implement storing bees on Fabric
+    }
+}

--- a/implementation/v1_21_R4/build.gradle.kts
+++ b/implementation/v1_21_R4/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.21.5-R0.1-SNAPSHOT")
 	compileOnly("org.jetbrains:annotations:20.1.0")
     compileOnly("com.github.AvarionMC:yaml:1.1.7")
+    compileOnly("net.fabricmc:fabric-loader:0.14.21")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/implementation/v1_21_R4/src/main/java/org/terraform/v1_21_R4/FabricNMSInjector.java
+++ b/implementation/v1_21_R4/src/main/java/org/terraform/v1_21_R4/FabricNMSInjector.java
@@ -1,0 +1,49 @@
+package org.terraform.v1_21_R4;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.jetbrains.annotations.Nullable;
+import org.terraform.coregen.BlockDataFixerAbstract;
+import org.terraform.coregen.fabric.FabricNMSInjectorAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataAbstract;
+import org.terraform.coregen.populatordata.PopulatorDataICAAbstract;
+import org.terraform.data.TerraformWorld;
+
+/**
+ * Placeholder Fabric injector for v1_21_R4.
+ */
+public class FabricNMSInjector extends FabricNMSInjectorAbstract {
+    @Override
+    public void startupTasks() {
+        CustomBiomeHandler.init();
+    }
+
+    @Override
+    public @Nullable BlockDataFixerAbstract getBlockDataFixer() {
+        return new BlockDataFixer();
+    }
+
+    @Override
+    public boolean attemptInject(ServerLevel world) {
+        TerraformWorld tw = TerraformWorld.get(world.dimension().location().toString(), world.getSeed());
+        tw.minY = -64;
+        tw.maxY = 320;
+        // TODO implement actual Fabric chunk generator injection
+        return false;
+    }
+
+    @Override
+    public PopulatorDataICAAbstract getICAData(ServerLevel world) {
+        return null;
+    }
+
+    @Override
+    public @Nullable PopulatorDataICAAbstract getICAData(PopulatorDataAbstract data) {
+        return null;
+    }
+
+    @Override
+    public void storeBee(ServerLevel world, BlockPos hivePos) {
+        // TODO implement storing bees on Fabric
+    }
+}


### PR DESCRIPTION
## Summary
- add `FabricNMSInjectorAbstract` for Fabric mod support
- register Fabric world load/unload events
- hook plugin to handle Fabric world lifecycle
- create Fabric injector skeletons for each implementation version
- include Fabric loader dependencies for implementation modules

## Testing
- `./gradlew build -x test` *(fails: Compilation errors due to missing Fabric API and Bukkit classes)*

------
https://chatgpt.com/codex/tasks/task_e_684142bac8f8832db7e7cd875e01cf11